### PR TITLE
Don't show the internal vacation-alias to the user

### DIFF
--- a/README
+++ b/README
@@ -66,6 +66,10 @@ $rcmail_config['forward_sql_read'] = query;
     default query: 'SELECT * FROM alias WHERE address = %address'
     example query: 'SELECT * FROM aliases WHERE address = %address'
 
+$rcmail_config['forward_vacation_domain'] = value;
+    just enter the same value as for $CONF['vacation_domain'] in
+    the Postfixadmin config file
+    example value: 'autoreply.change-this-to-your.domain.tld'
 
 
 LICENCE

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -17,4 +17,9 @@ $rcmail_config['forward_sql_write'] = 'UPDATE alias SET goto = %goto, modified =
 // The SQL query used to select aliases.
 $rcmail_config['forward_sql_read'] = 'SELECT * FROM alias WHERE address = %address';
 
+// The value of $CONF['vacation_domain'] in the Postfixadmin config file
+// If you are using postfixadmin vacation and don't set the right domain here,
+// additional aliases will show up in the roundcube settings forward page
+$rcmail_config['forward_vacation_domain'] = 'autoreply.change-this-to-your.domain.tld';
+
 ?>


### PR DESCRIPTION
I made some changes to the code so that vacation-aliases are filtered out upon reading and added again upon saving. This way, the user won't see the vacation-alias.
