### PR TITLE
Added: Now creates row if no previous alias record exists

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,3 +15,7 @@
         * some bug fixes
         * tested with RC 1.1.1
         [RELEASE]: version 1.1.0
+
+2016-09-25 Ray Deng (https://github.com/iBL1nK/)
+        * Now creates row if no previous alias record exists
+        * Clarified instructions on config.inc.php.dist and user interface 

--- a/README
+++ b/README
@@ -14,18 +14,19 @@ CONTRIBUTORS
 
 Sebastien Blaisot (https://github.com/sblaisot)
 Jan B. Fiedler (https://github.com/zuloo)
+Ray Deng (https://github.com/iBL1nK/)
 
 
 
 VERSION
 
-1.1.0
+1.1.1
 
 
 
 RELEASE DATE
 
-21-05-2015
+25-09-2016
 
 
 
@@ -40,7 +41,11 @@ add it to the plugin array in config/config.inc.php :
 // List of active plugins (in plugins/ directory)
 $rcmail_config['plugins'] = array('forward');
 
+note: if you have more than one plugin installed, add them to the array
+eg:
 
+// List of active plugins (in plugins/ directory)
+$rcmail_config['plugins'] = array('forward, PLUGIN2, PLUGIN3');
 
 CONFIGURATION
 
@@ -57,8 +62,8 @@ $rcmail_config['forward_sql_dsn'] = value;
 $rcmail_config['forward_sql_write'] = query;
     the query depends upon your postfixadmin database structure
     placeholders %goto and %address must be kept unchanged
-    default query: 'UPDATE alias SET goto = %goto, modified = %modified WHERE address = %address'
-    example query: 'UPDATE aliases SET forwardto = %goto, modified = %modified WHERE address = %address'
+    default query: 'REPLACE INTO alias SET address = %address, goto = %goto, modified = %modified, domain = %domain, created = %modified, active = "1"'
+    example query: 'REPLACE INTO aliases SET address = %address, forwardto = %goto, modified = %modified, domain = %domain, created = %modified'
 
 $rcmail_config['forward_sql_read'] = query;
     the query depends upon your postfixadmin database structure

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["mail","forward","forwards","pfa","postfixadmin"],
     "homepage": "https://github.com/gianlucagiacometti/roundcube-forward.git",
     "license": "GPL-2.0",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "authors": [
         {
             "name": "Gianluca Giacometti",
@@ -20,6 +20,11 @@
         {
             "name": "Jan B. Fiedler",
             "email": "zuloo@users.noreply.github.com",
+            "role": "Contributor"
+        },
+        {
+            "name": "Ray Deng",
+            "email": "ibl1nk@users.noreply.github.com",
             "role": "Contributor"
         }
     ],

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -12,7 +12,7 @@ $rcmail_config['forward_driver'] = 'sql';
 $rcmail_config['forward_sql_dsn'] = 'pgsql://username:password@host/database';
 
 // The SQL query used to update forwards.
-$rcmail_config['forward_sql_write'] = 'UPDATE alias SET goto = %goto, modified = %modified WHERE address = %address';
+$rcmail_config['forward_sql_write'] = 'REPLACE INTO alias SET address = %address, goto = %goto, modified = %modified, domain = %domain, created = %modified, active = "1"';
 
 // The SQL query used to select aliases.
 $rcmail_config['forward_sql_read'] = 'SELECT * FROM alias WHERE address = %address';

--- a/forward.php
+++ b/forward.php
@@ -198,8 +198,9 @@ class forward extends rcube_plugin {
 		$data['address'] = $this->obj->username;
 		$data['goto'] = $this->obj->get_forward_forwards();
 		$data['modified'] = date('Y-m-d H:i:s');
-
-		$ret = mail_forward_write ($data);
+                $data['domain'] = substr(strrchr($data['address'], "@"), 1);
+                
+                $ret = mail_forward_write ($data);
 		switch ($ret) {
 			case PLUGIN_ERROR_CONNECT:
 					$this->rc->output->command('display_message', $this->gettext('forwarddriverconnecterror'), 'error');

--- a/lib/drivers/sql.php
+++ b/lib/drivers/sql.php
@@ -67,7 +67,7 @@ function mail_forward_read(array &$data) {
 	else {
 		$data['goto'] = array();
 		}
-
+        
 	return PLUGIN_SUCCESS;
 
 	}
@@ -99,16 +99,18 @@ function mail_forward_write(array &$data) {
 	if ($err = $db->is_error()) {
 		return PLUGIN_ERROR_CONNECT;
 		}
-
+                
 	$search = array(
 			'%address',
 			'%goto',
-			'%modified'
+			'%modified',
+                        '%domain'
 			);
 	$replace = array(
 			$db->quote($data['address']),
 			$db->quote($data['goto']),
-			$db->quote($data['modified'])
+			$db->quote($data['modified']),
+                        $db->quote($data['domain'])
 			);
 	$query = str_replace($search, $replace, $rcmail->config->get('forward_sql_write'));
 

--- a/localization/en_GB.inc
+++ b/localization/en_GB.inc
@@ -4,7 +4,7 @@
 
 $labels = array();
 $labels['forward'] = 'Forward';
-$labels['forwardforwards'] = 'Forward addresses (separated by commas, semicolons or new lines)\nIf autoreply is set a forward address\ncontaining \'autoreply\' will appear; please do not delete or modify it';
+$labels['forwardforwards'] = 'Forward addresses (separated by "," commas, ";" semicolons or new lines) \n eg: email@email.com,email2@email2.com\nIf autoreply is set a forward address\ncontaining \'autoreply\' will appear; please do not delete or modify it';
 $labels['forwardkeepcopies'] = 'Keep copies of original messages';
 
 $messages = array();

--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -4,7 +4,7 @@
 
 $labels = array();
 $labels['forward'] = 'Forward';
-$labels['forwardforwards'] = 'Forward addresses (separated by commas, semicolons or new lines)\nIf autoreply is set a forward address\ncontaining \'autoreply\' will appear; please do not delete or modify it';
+$labels['forwardforwards'] = 'Forward addresses (separated by "," commas, ";" semicolons or new lines) \n eg: email@email.com,email2@email2.com\nIf autoreply is set a forward address\ncontaining \'autoreply\' will appear; please do not delete or modify it';
 $labels['forwardkeepcopies'] = 'Keep copies of original messages';
 
 $messages = array();


### PR DESCRIPTION
I had a problem with the plugin not doing anything if no previous alias record exists and where the SQL row didn't exist. I modified the plugin so that it now REPLACE INTO the SQL instead of UPDATE so that it creates a row if none is found. I also clarified some instructions.
